### PR TITLE
fix: the command is not called unless it is from a slash command

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,6 @@
 {
   "name": "command-config",
   "description": "Edits UbiquityOS configuration files based on natural language queries.",
-  "ubiquity:listeners": [
-    "issue_comment.created",
-    "pull_request_review_comment.created"
-  ],
   "commands": {
     "config": {
       "ubiquity:example": "/config <editor_instruction>",


### PR DESCRIPTION
Resolves #13

Removing these events from the manifest should only summon the command and not every comment happening.
<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
