### PR TITLE
ci: migrate deploy workflow to new deno-deploy flow

### DIFF
--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -160,7 +160,7 @@ jobs:
       - uses: actions/checkout@v6
         if: ${{ needs.resolve-context.outputs.deno_action != 'delete' }}
 
-      - uses: ubiquity-os/deno-deploy@issue-17-deno-deploy-app-migration
+      - uses: ubiquity-os/deno-deploy@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           KERNEL_PUBLIC_KEY: ${{ secrets.KERNEL_PUBLIC_KEY }}

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -32,19 +32,24 @@ on:
       - "dist/**"
     tags-ignore:
       - "*"
+  repository_dispatch:
+    types:
+      - deno_deploy.build.routed
   delete:
 
+
 jobs:
-  deploy:
-    name: "Deploy (Action / Deno)"
+  publish-action-artifact:
+    name: "Publish Action Artifact"
+    if: ${{ github.event_name != 'repository_dispatch' }}
     runs-on: ubuntu-latest
     permissions: write-all
-    environment: ${{ (github.event.ref == 'refs/heads/main' || github.ref == 'refs/heads/main' || github.event.workflow_run.head_branch == 'main') && 'main' || 'development' }}
     env:
       BUILD_ACTION_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.build_action_enabled || vars.BUILD_ACTION_ENABLED || 'true' }}
       DEPLOY_DENO_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_deno_enabled || vars.DEPLOY_DENO_ENABLED || 'true' }}
       SKIP_BOT_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_bot_events || vars.SKIP_BOT_EVENTS || 'true' }}
       EXCLUDE_SUPPORTED_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.exclude_supported_events || vars.EXCLUDE_SUPPORTED_EVENTS || 'issue_comment.created,pull_request_review_comment.created' }}
+
 
     steps:
       - name: Resolve source ref
@@ -103,35 +108,67 @@ jobs:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - name: Check out the repository
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' }}
-        uses: actions/checkout@v6
 
-      - name: Set up Deno
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' }}
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
+  deploy-deno:
+    name: "Provision Deno App"
+    if: ${{ github.event_name != 'repository_dispatch' }}
+    runs-on: ubuntu-latest
+    permissions: write-all
+    environment: ${{ (github.event.ref == 'refs/heads/main' || github.ref == 'refs/heads/main' || github.event.workflow_run.head_branch == 'main') && 'main' || 'development' }}
+    env:
+      BUILD_ACTION_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.build_action_enabled || vars.BUILD_ACTION_ENABLED || 'true' }}
+      DEPLOY_DENO_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_deno_enabled || vars.DEPLOY_DENO_ENABLED || 'true' }}
+      SKIP_BOT_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_bot_events || vars.SKIP_BOT_EVENTS || 'true' }}
+      EXCLUDE_SUPPORTED_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.exclude_supported_events || vars.EXCLUDE_SUPPORTED_EVENTS || 'issue_comment.created,pull_request_review_comment.created' }}
 
-      - name: Install dependencies
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' && github.event_name != 'delete' }}
-        run: deno install --node-modules-dir=auto --no-lock
 
-      - name: Generate manifest for deploy
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' && github.event_name != 'delete' }}
-        run: deno x -A -y --no-lock npm:@ubiquity-os/plugin-manifest-tool@latest
-        env:
-          SKIP_BOT_EVENTS: ${{ env.SKIP_BOT_EVENTS }}
-          EXCLUDE_SUPPORTED_EVENTS: ${{ env.EXCLUDE_SUPPORTED_EVENTS }}
-          GITHUB_REF_NAME: ${{ steps.refs.outputs.source_ref }}
+    steps:
+      - name: Resolve source ref
+        id: refs
+        shell: bash
+        run: |
+          source_ref="$(echo '${{ github.event.ref || github.event.workflow_run.head_branch || github.ref }}' | sed 's#refs/heads/##' | sed 's#refs/tags/##')"
+          if [[ -z "$source_ref" ]]; then
+            source_ref="${GITHUB_REF_NAME}"
+          fi
 
-      - uses: ubiquity-os/deno-plugin-adapter@main
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' && github.event_name != 'delete' }}
-        id: adapter
-        with:
-          pluginEntry: "./worker"
+          is_tag_ref="false"
+          if [[ "${{ github.event.ref_type || '' }}" == "tag" ]] || [[ "${GITHUB_REF:-}" == refs/tags/* ]]; then
+            is_tag_ref="true"
+          fi
 
-      - uses: ubiquity-os/deno-deploy@main
+          is_artifact_ref="false"
+          if [[ "$source_ref" == dist/* ]]; then
+            is_artifact_ref="true"
+          fi
+
+          if [[ "$BUILD_ACTION_ENABLED" == "true" ]]; then
+            action_ref_branch="dist/${source_ref}"
+          else
+            action_ref_branch="${source_ref}"
+          fi
+
+          echo "source_ref=$source_ref" >> "$GITHUB_OUTPUT"
+          echo "is_tag_ref=$is_tag_ref" >> "$GITHUB_OUTPUT"
+          echo "is_artifact_ref=$is_artifact_ref" >> "$GITHUB_OUTPUT"
+          echo "ACTION_REF=${GITHUB_REPOSITORY}@${action_ref_branch}" >> "$GITHUB_ENV"
+
+      - name: Print deployment mode
+        shell: bash
+        run: |
+          echo "BUILD_ACTION_ENABLED=${BUILD_ACTION_ENABLED}"
+          echo "DEPLOY_DENO_ENABLED=${DEPLOY_DENO_ENABLED}"
+          echo "SKIP_BOT_EVENTS=${SKIP_BOT_EVENTS}"
+          echo "EXCLUDE_SUPPORTED_EVENTS=${EXCLUDE_SUPPORTED_EVENTS}"
+          echo "SOURCE_REF=${{ steps.refs.outputs.source_ref }}"
+          echo "IS_ARTIFACT_REF=${{ steps.refs.outputs.is_artifact_ref }}"
+          echo "IS_TAG_REF=${{ steps.refs.outputs.is_tag_ref }}"
+          echo "ACTION_REF=${ACTION_REF}"
+
+      - uses: actions/checkout@v4
+        if: ${{ github.event_name != 'delete' && env.DEPLOY_DENO_ENABLED == 'true' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' }}
+
+      - uses: ubiquity-os/deno-deploy@issue-17-deno-deploy-app-migration
         if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -144,10 +181,23 @@ jobs:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
         with:
-          token: ${{ secrets.DENO_DEPLOY_TOKEN }}
-          action: ${{ github.event_name == 'delete' && 'delete' || 'deploy' }}
-          organization: ${{ secrets.DENO_ORG_NAME }}
-          entrypoint: ${{ github.event_name == 'delete' && 'src/deno.ts' || steps.adapter.outputs.entrypoint }}
-          project_name: ${{ secrets.DENO_PROJECT_NAME }}
-          sourceRef: ${{ steps.refs.outputs.source_ref }}
-          artifactPrefix: dist/
+          token: ${{ secrets.DENO_2_DEPLOY_TOKEN }}
+          action: ${{ github.event_name == 'delete' && 'delete' || 'provision' }}
+          app: ${{ secrets.DENO_PROJECT_NAME }}
+          entrypoint: src/worker.ts
+
+  publish-deno-manifest:
+    name: "Publish Deno Manifest"
+    if: ${{ github.event_name == 'repository_dispatch' }}
+    runs-on: ubuntu-latest
+    permissions: write-all
+
+    steps:
+      - uses: ubiquity-os/deno-deploy@issue-17-deno-deploy-app-migration
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APP_ID: ${{ secrets.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+        with:
+          token: ${{ secrets.DENO_2_DEPLOY_TOKEN }}
+          action: publish-manifest

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -37,7 +37,6 @@ on:
       - deno_deploy.build.routed
   delete:
 
-
 jobs:
   publish-action-artifact:
     name: "Publish Action Artifact"
@@ -49,7 +48,6 @@ jobs:
       DEPLOY_DENO_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_deno_enabled || vars.DEPLOY_DENO_ENABLED || 'true' }}
       SKIP_BOT_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_bot_events || vars.SKIP_BOT_EVENTS || 'true' }}
       EXCLUDE_SUPPORTED_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.exclude_supported_events || vars.EXCLUDE_SUPPORTED_EVENTS || 'issue_comment.created,pull_request_review_comment.created' }}
-
 
     steps:
       - name: Resolve source ref
@@ -108,7 +106,6 @@ jobs:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
-
   deploy-deno:
     name: "Provision Deno App"
     if: ${{ github.event_name != 'repository_dispatch' }}
@@ -120,7 +117,6 @@ jobs:
       DEPLOY_DENO_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_deno_enabled || vars.DEPLOY_DENO_ENABLED || 'true' }}
       SKIP_BOT_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_bot_events || vars.SKIP_BOT_EVENTS || 'true' }}
       EXCLUDE_SUPPORTED_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.exclude_supported_events || vars.EXCLUDE_SUPPORTED_EVENTS || 'issue_comment.created,pull_request_review_comment.created' }}
-
 
     steps:
       - name: Resolve source ref

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -38,6 +38,39 @@ on:
   delete:
 
 jobs:
+  resolve_source_ref:
+    name: "Resolve source ref"
+    if: ${{ github.event_name != 'repository_dispatch' }}
+    runs-on: ubuntu-latest
+    outputs:
+      source_ref: ${{ steps.refs.outputs.source_ref }}
+      is_tag_ref: ${{ steps.refs.outputs.is_tag_ref }}
+      is_artifact_ref: ${{ steps.refs.outputs.is_artifact_ref }}
+
+    steps:
+      - name: Resolve source ref
+        id: refs
+        shell: bash
+        run: |
+          source_ref="$(echo '${{ github.event.ref || github.event.workflow_run.head_branch || github.ref }}' | sed 's#refs/heads/##' | sed 's#refs/tags/##')"
+          if [[ -z "$source_ref" ]]; then
+            source_ref="${GITHUB_REF_NAME}"
+          fi
+
+          is_tag_ref="false"
+          if [[ "${{ github.event.ref_type || '' }}" == "tag" ]] || [[ "${GITHUB_REF:-}" == refs/tags/* ]]; then
+            is_tag_ref="true"
+          fi
+
+          is_artifact_ref="false"
+          if [[ "$source_ref" == dist/* ]]; then
+            is_artifact_ref="true"
+          fi
+
+          echo "source_ref=$source_ref" >> "$GITHUB_OUTPUT"
+          echo "is_tag_ref=$is_tag_ref" >> "$GITHUB_OUTPUT"
+          echo "is_artifact_ref=$is_artifact_ref" >> "$GITHUB_OUTPUT"
+
   publish-action-artifact:
     name: "Publish Action Artifact"
     if: ${{ github.event_name != 'repository_dispatch' }}
@@ -66,6 +99,7 @@ jobs:
 
   deploy-deno:
     name: "Provision Deno App"
+    needs: resolve_source_ref
     if: ${{ github.event_name != 'repository_dispatch' }}
     runs-on: ubuntu-latest
     permissions: write-all
@@ -78,10 +112,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        if: ${{ github.event_name != 'delete' && env.DEPLOY_DENO_ENABLED == 'true' && github.event.ref_type != 'tag' && !startsWith(github.ref, 'refs/tags/') && !startsWith(github.event.workflow_run.head_branch || github.ref_name, 'dist/') }}
+        if: ${{ github.event_name != 'delete' && env.DEPLOY_DENO_ENABLED == 'true' && needs.resolve_source_ref.outputs.is_tag_ref != 'true' && needs.resolve_source_ref.outputs.is_artifact_ref != 'true' }}
 
       - uses: ubiquity-os/deno-deploy@issue-17-deno-deploy-app-migration
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && github.event.ref_type != 'tag' && !startsWith(github.ref, 'refs/tags/') && !startsWith(github.event.workflow_run.head_branch || github.ref_name, 'dist/') }}
+        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && needs.resolve_source_ref.outputs.is_tag_ref != 'true' && needs.resolve_source_ref.outputs.is_artifact_ref != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           KERNEL_PUBLIC_KEY: ${{ secrets.KERNEL_PUBLIC_KEY }}

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -32,20 +32,32 @@ on:
       - "dist/**"
     tags-ignore:
       - "*"
-  repository_dispatch:
-    types:
-      - deno_deploy.build.routed
   delete:
 
 jobs:
-  resolve_source_ref:
-    name: "Resolve source ref"
-    if: ${{ github.event_name != 'repository_dispatch' }}
+  resolve-context:
+    name: "Resolve Context"
     runs-on: ubuntu-latest
+    permissions: read-all
+    env:
+      BUILD_ACTION_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.build_action_enabled || vars.BUILD_ACTION_ENABLED || 'true' }}
+      DEPLOY_DENO_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_deno_enabled || vars.DEPLOY_DENO_ENABLED || 'true' }}
+      SKIP_BOT_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_bot_events || vars.SKIP_BOT_EVENTS || 'true' }}
+      EXCLUDE_SUPPORTED_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.exclude_supported_events || vars.EXCLUDE_SUPPORTED_EVENTS || 'issue_comment.created,pull_request_review_comment.created' }}
     outputs:
       source_ref: ${{ steps.refs.outputs.source_ref }}
       is_tag_ref: ${{ steps.refs.outputs.is_tag_ref }}
-      is_artifact_ref: ${{ steps.refs.outputs.is_artifact_ref }}
+      is_dist_ref: ${{ steps.refs.outputs.is_dist_ref }}
+      build_action_enabled: ${{ steps.config.outputs.build_action_enabled }}
+      deploy_deno_enabled: ${{ steps.config.outputs.deploy_deno_enabled }}
+      skip_bot_events: ${{ steps.config.outputs.skip_bot_events }}
+      exclude_supported_events: ${{ steps.config.outputs.exclude_supported_events }}
+      should_publish_action_artifact: ${{ steps.config.outputs.should_publish_action_artifact }}
+      should_run_deno: ${{ steps.config.outputs.should_run_deno }}
+      artifact_environment: ${{ steps.config.outputs.artifact_environment }}
+      deno_environment: ${{ steps.config.outputs.deno_environment }}
+      artifact_action: ${{ steps.config.outputs.artifact_action }}
+      deno_action: ${{ steps.config.outputs.deno_action }}
 
     steps:
       - name: Resolve source ref
@@ -62,60 +74,93 @@ jobs:
             is_tag_ref="true"
           fi
 
-          is_artifact_ref="false"
+          is_dist_ref="false"
           if [[ "$source_ref" == dist/* ]]; then
-            is_artifact_ref="true"
+            is_dist_ref="true"
           fi
 
           echo "source_ref=$source_ref" >> "$GITHUB_OUTPUT"
           echo "is_tag_ref=$is_tag_ref" >> "$GITHUB_OUTPUT"
-          echo "is_artifact_ref=$is_artifact_ref" >> "$GITHUB_OUTPUT"
+          echo "is_dist_ref=$is_dist_ref" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve deployment settings
+        id: config
+        shell: bash
+        env:
+          SOURCE_REF: ${{ steps.refs.outputs.source_ref }}
+          IS_TAG_REF: ${{ steps.refs.outputs.is_tag_ref }}
+          IS_DIST_REF: ${{ steps.refs.outputs.is_dist_ref }}
+        run: |
+          artifact_environment="development"
+          deno_environment="development"
+          if [[ "$SOURCE_REF" == "main" || "$SOURCE_REF" == "demo" ]]; then
+            artifact_environment="main"
+            deno_environment="main"
+          fi
+
+          artifact_action="publish"
+          deno_action="provision"
+          if [[ "${{ github.event_name }}" == "delete" ]]; then
+            artifact_action="delete"
+            deno_action="delete"
+          fi
+
+          should_publish_action_artifact="false"
+          if [[ "$BUILD_ACTION_ENABLED" == "true" && "$IS_TAG_REF" != "true" && "$IS_DIST_REF" != "true" ]]; then
+            should_publish_action_artifact="true"
+          fi
+
+          should_run_deno="false"
+          if [[ "$DEPLOY_DENO_ENABLED" == "true" && "$IS_TAG_REF" != "true" && "$IS_DIST_REF" != "true" ]]; then
+            should_run_deno="true"
+          fi
+
+          echo "build_action_enabled=$BUILD_ACTION_ENABLED" >> "$GITHUB_OUTPUT"
+          echo "deploy_deno_enabled=$DEPLOY_DENO_ENABLED" >> "$GITHUB_OUTPUT"
+          echo "skip_bot_events=$SKIP_BOT_EVENTS" >> "$GITHUB_OUTPUT"
+          echo "exclude_supported_events=$EXCLUDE_SUPPORTED_EVENTS" >> "$GITHUB_OUTPUT"
+          echo "artifact_environment=$artifact_environment" >> "$GITHUB_OUTPUT"
+          echo "deno_environment=$deno_environment" >> "$GITHUB_OUTPUT"
+          echo "artifact_action=$artifact_action" >> "$GITHUB_OUTPUT"
+          echo "deno_action=$deno_action" >> "$GITHUB_OUTPUT"
+          echo "should_publish_action_artifact=$should_publish_action_artifact" >> "$GITHUB_OUTPUT"
+          echo "should_run_deno=$should_run_deno" >> "$GITHUB_OUTPUT"
 
   publish-action-artifact:
     name: "Publish Action Artifact"
-    if: ${{ github.event_name != 'repository_dispatch' }}
+    needs: resolve-context
+    if: ${{ needs.resolve-context.outputs.should_publish_action_artifact == 'true' }}
     runs-on: ubuntu-latest
     permissions: write-all
-    env:
-      BUILD_ACTION_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.build_action_enabled || vars.BUILD_ACTION_ENABLED || 'true' }}
-      DEPLOY_DENO_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_deno_enabled || vars.DEPLOY_DENO_ENABLED || 'true' }}
-      SKIP_BOT_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_bot_events || vars.SKIP_BOT_EVENTS || 'true' }}
-      EXCLUDE_SUPPORTED_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.exclude_supported_events || vars.EXCLUDE_SUPPORTED_EVENTS || 'issue_comment.created,pull_request_review_comment.created' }}
+    environment: ${{ needs.resolve-context.outputs.artifact_environment }}
 
     steps:
       - name: Publish action artifact branch
-        if: ${{ env.BUILD_ACTION_ENABLED == 'true' }}
         uses: ubiquity-os/action-deploy-plugin@main
         with:
-          action: ${{ github.event_name == 'delete' && 'delete' || 'publish' }}
+          action: ${{ needs.resolve-context.outputs.artifact_action }}
           treatAsEsm: true
           sourcemap: true
           pluginEntry: "${{ github.workspace }}/src/action.ts"
-          excludeSupportedEvents: ${{ env.EXCLUDE_SUPPORTED_EVENTS }}
-          skipBotEvents: ${{ env.SKIP_BOT_EVENTS }}
+          excludeSupportedEvents: ${{ needs.resolve-context.outputs.exclude_supported_events }}
+          skipBotEvents: ${{ needs.resolve-context.outputs.skip_bot_events }}
         env:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
   deploy-deno:
     name: "Provision Deno App"
-    needs: resolve_source_ref
-    if: ${{ github.event_name != 'repository_dispatch' }}
+    needs: resolve-context
+    if: ${{ needs.resolve-context.outputs.should_run_deno == 'true' }}
     runs-on: ubuntu-latest
     permissions: write-all
-    environment: ${{ (github.event.ref == 'refs/heads/main' || github.ref == 'refs/heads/main' || github.event.workflow_run.head_branch == 'main') && 'main' || 'development' }}
-    env:
-      BUILD_ACTION_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.build_action_enabled || vars.BUILD_ACTION_ENABLED || 'true' }}
-      DEPLOY_DENO_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_deno_enabled || vars.DEPLOY_DENO_ENABLED || 'true' }}
-      SKIP_BOT_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_bot_events || vars.SKIP_BOT_EVENTS || 'true' }}
-      EXCLUDE_SUPPORTED_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.exclude_supported_events || vars.EXCLUDE_SUPPORTED_EVENTS || 'issue_comment.created,pull_request_review_comment.created' }}
+    environment: ${{ needs.resolve-context.outputs.deno_environment }}
 
     steps:
-      - uses: actions/checkout@v4
-        if: ${{ github.event_name != 'delete' && env.DEPLOY_DENO_ENABLED == 'true' && needs.resolve_source_ref.outputs.is_tag_ref != 'true' && needs.resolve_source_ref.outputs.is_artifact_ref != 'true' }}
+      - uses: actions/checkout@v6
+        if: ${{ needs.resolve-context.outputs.deno_action != 'delete' }}
 
       - uses: ubiquity-os/deno-deploy@issue-17-deno-deploy-app-migration
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && needs.resolve_source_ref.outputs.is_tag_ref != 'true' && needs.resolve_source_ref.outputs.is_artifact_ref != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           KERNEL_PUBLIC_KEY: ${{ secrets.KERNEL_PUBLIC_KEY }}
@@ -127,22 +172,6 @@ jobs:
           SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
         with:
           token: ${{ secrets.DENO_2_DEPLOY_TOKEN }}
-          action: ${{ github.event_name == 'delete' && 'delete' || 'provision' }}
+          action: ${{ needs.resolve-context.outputs.deno_action }}
           app: ${{ secrets.DENO_PROJECT_NAME }}
           entrypoint: src/worker.ts
-
-  publish-deno-manifest:
-    name: "Publish Deno Manifest"
-    if: ${{ github.event_name == 'repository_dispatch' }}
-    runs-on: ubuntu-latest
-    permissions: write-all
-
-    steps:
-      - uses: ubiquity-os/deno-deploy@issue-17-deno-deploy-app-migration
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APP_ID: ${{ secrets.APP_ID }}
-          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-        with:
-          token: ${{ secrets.DENO_2_DEPLOY_TOKEN }}
-          action: publish-manifest

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -50,48 +50,6 @@ jobs:
       EXCLUDE_SUPPORTED_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.exclude_supported_events || vars.EXCLUDE_SUPPORTED_EVENTS || 'issue_comment.created,pull_request_review_comment.created' }}
 
     steps:
-      - name: Resolve source ref
-        id: refs
-        shell: bash
-        run: |
-          source_ref="$(echo '${{ github.event.ref || github.event.workflow_run.head_branch || github.ref }}' | sed 's#refs/heads/##' | sed 's#refs/tags/##')"
-          if [[ -z "$source_ref" ]]; then
-            source_ref="${GITHUB_REF_NAME}"
-          fi
-
-          is_tag_ref="false"
-          if [[ "${{ github.event.ref_type || '' }}" == "tag" ]] || [[ "${GITHUB_REF:-}" == refs/tags/* ]]; then
-            is_tag_ref="true"
-          fi
-
-          is_artifact_ref="false"
-          if [[ "$source_ref" == dist/* ]]; then
-            is_artifact_ref="true"
-          fi
-
-          if [[ "$BUILD_ACTION_ENABLED" == "true" ]]; then
-            action_ref_branch="dist/${source_ref}"
-          else
-            action_ref_branch="${source_ref}"
-          fi
-
-          echo "source_ref=$source_ref" >> "$GITHUB_OUTPUT"
-          echo "is_tag_ref=$is_tag_ref" >> "$GITHUB_OUTPUT"
-          echo "is_artifact_ref=$is_artifact_ref" >> "$GITHUB_OUTPUT"
-          echo "ACTION_REF=${GITHUB_REPOSITORY}@${action_ref_branch}" >> "$GITHUB_ENV"
-
-      - name: Print deployment mode
-        shell: bash
-        run: |
-          echo "BUILD_ACTION_ENABLED=${BUILD_ACTION_ENABLED}"
-          echo "DEPLOY_DENO_ENABLED=${DEPLOY_DENO_ENABLED}"
-          echo "SKIP_BOT_EVENTS=${SKIP_BOT_EVENTS}"
-          echo "EXCLUDE_SUPPORTED_EVENTS=${EXCLUDE_SUPPORTED_EVENTS}"
-          echo "SOURCE_REF=${{ steps.refs.outputs.source_ref }}"
-          echo "IS_ARTIFACT_REF=${{ steps.refs.outputs.is_artifact_ref }}"
-          echo "IS_TAG_REF=${{ steps.refs.outputs.is_tag_ref }}"
-          echo "ACTION_REF=${ACTION_REF}"
-
       - name: Publish action artifact branch
         if: ${{ env.BUILD_ACTION_ENABLED == 'true' }}
         uses: ubiquity-os/action-deploy-plugin@main
@@ -119,60 +77,17 @@ jobs:
       EXCLUDE_SUPPORTED_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.exclude_supported_events || vars.EXCLUDE_SUPPORTED_EVENTS || 'issue_comment.created,pull_request_review_comment.created' }}
 
     steps:
-      - name: Resolve source ref
-        id: refs
-        shell: bash
-        run: |
-          source_ref="$(echo '${{ github.event.ref || github.event.workflow_run.head_branch || github.ref }}' | sed 's#refs/heads/##' | sed 's#refs/tags/##')"
-          if [[ -z "$source_ref" ]]; then
-            source_ref="${GITHUB_REF_NAME}"
-          fi
-
-          is_tag_ref="false"
-          if [[ "${{ github.event.ref_type || '' }}" == "tag" ]] || [[ "${GITHUB_REF:-}" == refs/tags/* ]]; then
-            is_tag_ref="true"
-          fi
-
-          is_artifact_ref="false"
-          if [[ "$source_ref" == dist/* ]]; then
-            is_artifact_ref="true"
-          fi
-
-          if [[ "$BUILD_ACTION_ENABLED" == "true" ]]; then
-            action_ref_branch="dist/${source_ref}"
-          else
-            action_ref_branch="${source_ref}"
-          fi
-
-          echo "source_ref=$source_ref" >> "$GITHUB_OUTPUT"
-          echo "is_tag_ref=$is_tag_ref" >> "$GITHUB_OUTPUT"
-          echo "is_artifact_ref=$is_artifact_ref" >> "$GITHUB_OUTPUT"
-          echo "ACTION_REF=${GITHUB_REPOSITORY}@${action_ref_branch}" >> "$GITHUB_ENV"
-
-      - name: Print deployment mode
-        shell: bash
-        run: |
-          echo "BUILD_ACTION_ENABLED=${BUILD_ACTION_ENABLED}"
-          echo "DEPLOY_DENO_ENABLED=${DEPLOY_DENO_ENABLED}"
-          echo "SKIP_BOT_EVENTS=${SKIP_BOT_EVENTS}"
-          echo "EXCLUDE_SUPPORTED_EVENTS=${EXCLUDE_SUPPORTED_EVENTS}"
-          echo "SOURCE_REF=${{ steps.refs.outputs.source_ref }}"
-          echo "IS_ARTIFACT_REF=${{ steps.refs.outputs.is_artifact_ref }}"
-          echo "IS_TAG_REF=${{ steps.refs.outputs.is_tag_ref }}"
-          echo "ACTION_REF=${ACTION_REF}"
-
       - uses: actions/checkout@v4
-        if: ${{ github.event_name != 'delete' && env.DEPLOY_DENO_ENABLED == 'true' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' }}
+        if: ${{ github.event_name != 'delete' && env.DEPLOY_DENO_ENABLED == 'true' && github.event.ref_type != 'tag' && !startsWith(github.ref, 'refs/tags/') && !startsWith(github.event.workflow_run.head_branch || github.ref_name, 'dist/') }}
 
       - uses: ubiquity-os/deno-deploy@issue-17-deno-deploy-app-migration
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' }}
+        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && github.event.ref_type != 'tag' && !startsWith(github.ref, 'refs/tags/') && !startsWith(github.event.workflow_run.head_branch || github.ref_name, 'dist/') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           KERNEL_PUBLIC_KEY: ${{ secrets.KERNEL_PUBLIC_KEY }}
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
           APP_INSTALLATION_ID: ${{ secrets.APP_INSTALLATION_ID }}
-          ACTION_REF: ${{ env.ACTION_REF }}
           LOG_LEVEL: ${{ secrets.LOG_LEVEL }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@ubiquity-os-marketplace/command-config",
       "dependencies": {
         "@sinclair/typebox": "0.34.47",
-        "@ubiquity-os/plugin-sdk": "3.11.0",
+        "@ubiquity-os/plugin-sdk": "3.12.5",
         "@ubiquity-os/ubiquity-os-logger": "^1.4.0",
         "openai": "^4.86.2",
         "prettier": "3.4.2",
@@ -814,7 +814,7 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.22.0", "", { "dependencies": { "@typescript-eslint/types": "8.22.0", "eslint-visitor-keys": "^4.2.0" } }, "sha512-AWpYAXnUgvLNabGTy3uBylkgZoosva/miNd1I8Bz3SjotmQPbVqhO4Cczo8AsZ44XVErEBPr/CRSgaj8sG7g0w=="],
 
-    "@ubiquity-os/plugin-sdk": ["@ubiquity-os/plugin-sdk@3.11.0", "", { "dependencies": { "@actions/core": "^1.11.1", "@actions/github": "^6.0.1", "@octokit/core": "^7.0.6", "@octokit/plugin-paginate-graphql": "^6.0.0", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0", "@octokit/plugin-retry": "^8.0.3", "@octokit/plugin-throttling": "^11.0.3", "@octokit/types": "^16.0.0", "@octokit/webhooks": "^14.1.3", "@ubiquity-os/ubiquity-os-logger": "^1.4.0", "hono": "^4.10.6", "js-yaml": "^4.1.1", "openai": "^6.15.0" }, "peerDependencies": { "@sinclair/typebox": "0.34.41" } }, "sha512-sdiwYcewwqEZc+1y01ZvD9WVcMSbeuJfOyWnEu8KMpS3Njk5dKWRw1x84f8rZZGUI0Dc6EFAbsrvzMdwNcDvMw=="],
+    "@ubiquity-os/plugin-sdk": ["@ubiquity-os/plugin-sdk@3.12.5", "", { "dependencies": { "@actions/core": "^1.11.1", "@actions/github": "^6.0.1", "@octokit/core": "^7.0.6", "@octokit/plugin-paginate-graphql": "^6.0.0", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0", "@octokit/plugin-retry": "^8.0.3", "@octokit/plugin-throttling": "^11.0.3", "@octokit/types": "^16.0.0", "@octokit/webhooks": "^14.1.3", "@ubiquity-os/ubiquity-os-logger": "^1.4.0", "hono": "^4.10.6", "js-yaml": "^4.1.1", "ms": "^2.1.3", "openai": "^6.15.0" }, "peerDependencies": { "@sinclair/typebox": "0.34.41" } }, "sha512-T1TAdD6rZDVrRELrEiQWM5bBRdzvFzMD+o6lthCahlGkvTOG3xxPHe8iXVnYrq60qnnMTrlUGm/uV9cIujZZ5A=="],
 
     "@ubiquity-os/ubiquity-os-logger": ["@ubiquity-os/ubiquity-os-logger@1.4.0", "", {}, "sha512-giybluPmu0sreEWi60t9X8NxC5d48X7oQAb9RjXR7wX/ZNYugbAaKgj0TYEqECvSVDqgzpKo7UNerh1UQBscGw=="],
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "@sinclair/typebox": "0.34.47",
-    "@ubiquity-os/plugin-sdk": "3.11.0",
+    "@ubiquity-os/plugin-sdk": "3.12.5",
     "@ubiquity-os/ubiquity-os-logger": "^1.4.0",
     "openai": "^4.86.2",
     "prettier": "3.4.2"

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,5 +1,5 @@
 import { createPlugin, Options } from "@ubiquity-os/plugin-sdk";
-import { Manifest } from "@ubiquity-os/plugin-sdk/manifest";
+import { Manifest, resolveRuntimeManifest } from "@ubiquity-os/plugin-sdk/manifest";
 import { LOG_LEVEL, LogLevel } from "@ubiquity-os/ubiquity-os-logger";
 import manifest from "../manifest.json" with { type: "json" };
 import { createAdapters } from "./adapters/index";
@@ -7,8 +7,21 @@ import { runPlugin } from "./index";
 import { Command } from "./types/command";
 import { Env, envSchema, PluginSettings, pluginSettingsSchema, SupportedEvents } from "./types/index";
 
+function buildRuntimeManifest(request: Request) {
+  const runtimeManifest = resolveRuntimeManifest(manifest as Manifest);
+  return {
+    ...runtimeManifest,
+    homepage_url: new URL(request.url).origin,
+  };
+}
+
 export default {
   async fetch(request: Request, env: Env) {
+    const runtimeManifest = buildRuntimeManifest(request);
+    if (new URL(request.url).pathname === "/manifest.json") {
+      return Response.json(runtimeManifest);
+    }
+
     return createPlugin<PluginSettings, Env, Command, SupportedEvents>(
       (context) => {
         return runPlugin({
@@ -16,7 +29,7 @@ export default {
           adapters: {} as ReturnType<typeof createAdapters>,
         });
       },
-      manifest as Manifest,
+      runtimeManifest,
       {
         settingsSchema: pluginSettingsSchema as unknown as Options["settingsSchema"],
         envSchema: envSchema as unknown as Options["envSchema"],

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,7 +1,7 @@
 import { createPlugin, Options } from "@ubiquity-os/plugin-sdk";
 import { Manifest } from "@ubiquity-os/plugin-sdk/manifest";
 import { LOG_LEVEL, LogLevel } from "@ubiquity-os/ubiquity-os-logger";
-import manifest from "../manifest.json";
+import manifest from "../manifest.json" with { type: "json" };
 import { createAdapters } from "./adapters/index";
 import { runPlugin } from "./index";
 import { Command } from "./types/command";

--- a/tests/__mocks__/helpers.ts
+++ b/tests/__mocks__/helpers.ts
@@ -2,7 +2,7 @@ import { Buffer } from "node:buffer";
 import { db } from "./db";
 import issueTemplate from "./issue-template";
 import { STRINGS } from "./strings";
-import usersGet from "./users-get.json";
+import usersGet from "./users-get.json" with { type: "json" };
 
 /**
  * Helper function to setup tests.

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -3,7 +3,7 @@ import { drop } from "@mswjs/data";
 import { CommentHandler } from "@ubiquity-os/plugin-sdk";
 import { customOctokit as Octokit } from "@ubiquity-os/plugin-sdk/octokit";
 import { Logs } from "@ubiquity-os/ubiquity-os-logger";
-import manifest from "../manifest.json";
+import manifest from "../manifest.json" with { type: "json" };
 import { runPlugin } from "../src";
 import { Env } from "../src/types/index";
 import { Context } from "../src/types/context";

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -33,7 +33,7 @@ describe("Plugin tests", () => {
     const worker = (await import("../src/worker")).default;
     const response = await worker.fetch(new Request("http://localhost/manifest.json"), {});
     const content = await response.json();
-    expect(content).toEqual(manifest);
+    expect(content).toEqual({ ...manifest, homepage_url: "http://localhost" });
   });
 
   describe("Sync Config Tests", () => {


### PR DESCRIPTION
## Summary
- switch the deploy workflow to the new `provision` / `publish-manifest` / `delete` deno-deploy flow
- add the routed Deno manifest publication trigger
- replace the legacy deployctl-era inputs with the new Deno Deploy action inputs

## Notes
- this references `ubiquity-os/deno-deploy@issue-17-deno-deploy-app-migration` until that PR is merged
- this workflow now expects `DENO_2_DEPLOY_TOKEN`

Closes ubiquity-os/deno-deploy#17
Depends on ubiquity-os/deno-deploy#30