### PR TITLE
feat: resolve latest plugin refs to commit sha

### DIFF
--- a/src/helpers/plugin-alias.ts
+++ b/src/helpers/plugin-alias.ts
@@ -148,3 +148,10 @@ export function expandPluginInstallShorthand(instruction: string, index: PluginA
 
   return { expandedInstruction, replacements, ambiguous };
 }
+
+export function parseConfigPluginKey(key: string): { owner: string; repo: string; ref: string } | null {
+  if (URL_REGEX.test(key)) return null;
+  const match = /^([0-9A-Za-z._-]+)\/([0-9A-Za-z._-]+)@([^\s:]+)$/.exec(key.trim());
+  if (!match) return null;
+  return { owner: match[1], repo: match[2], ref: match[3] };
+}

--- a/src/helpers/process-targets.ts
+++ b/src/helpers/process-targets.ts
@@ -4,6 +4,8 @@ import { Context } from "../types/index";
 import { Target } from "../types/target";
 import { applyChanges } from "./apply-changes";
 import { getFileContent } from "./get-file-content";
+import { buildPluginAliasIndex, expandPluginInstallShorthand } from "./plugin-alias";
+import { resolveLatestPluginRefs } from "./resolve-latest-plugin-refs";
 
 async function maybeFormatYaml(content: string, context: Context): Promise<string> {
   if (process.env.JEST_WORKER_ID) return content;
@@ -47,8 +49,15 @@ export async function processTargetRepos(
   const prompt = adapters.llm.completions.promptBuilder(currentFileContents, manifestStore ?? {}, target.url);
   context.logger.info("Built prompt for YAML editor.", { chars: prompt.length });
 
+  let resolvedEditorInstruction = editorInstruction.trim();
+  if (manifestStore) {
+    const aliasExpansion = expandPluginInstallShorthand(resolvedEditorInstruction, buildPluginAliasIndex(manifestStore));
+    resolvedEditorInstruction = aliasExpansion.expandedInstruction;
+  }
+  resolvedEditorInstruction = await resolveLatestPluginRefs(resolvedEditorInstruction, context);
+
   // Update the file with the new content by making a LLM call
-  const llmResponse = await adapters.llm.completions.createCompletions(prompt, editorInstruction.trim());
+  const llmResponse = await adapters.llm.completions.createCompletions(prompt, resolvedEditorInstruction);
   context.logger.info("LLM response received.", { attempts: llmResponse.metadata.attempts, outputChars: llmResponse.text.length });
 
   const updatedFileContents = extractYamlOnly(llmResponse.text);

--- a/src/helpers/resolve-latest-plugin-refs.ts
+++ b/src/helpers/resolve-latest-plugin-refs.ts
@@ -1,0 +1,37 @@
+import { Context } from "../types/index";
+import { parseConfigPluginKey } from "./plugin-alias";
+
+async function getDefaultBranchHeadSha(context: Context, owner: string, repo: string): Promise<string> {
+  const { data: repository } = await context.octokit.rest.repos.get({ owner, repo });
+  const defaultBranch = repository.default_branch || "main";
+  const { data: ref } = await context.octokit.rest.git.getRef({
+    owner,
+    repo,
+    ref: `heads/${defaultBranch}`,
+  });
+  return ref.object.sha;
+}
+
+export async function resolveLatestPluginRefs(instruction: string, context: Context): Promise<string> {
+  const matches = [...instruction.matchAll(/\b(?<key>[0-9A-Za-z._-]+\/[0-9A-Za-z._-]+@latest)\b/g)];
+  if (matches.length === 0) return instruction;
+
+  const replacements = new Map<string, string>();
+
+  for (const match of matches) {
+    const key = match.groups?.key;
+    if (!key || replacements.has(key)) continue;
+
+    const parsed = parseConfigPluginKey(key);
+    if (!parsed || parsed.ref.toLowerCase() !== "latest") continue;
+
+    const sha = await getDefaultBranchHeadSha(context, parsed.owner, parsed.repo);
+    replacements.set(key, `${parsed.owner}/${parsed.repo}@${sha}`);
+  }
+
+  let updated = instruction;
+  for (const [from, to] of replacements) {
+    updated = updated.replaceAll(from, to);
+  }
+  return updated;
+}

--- a/tests/helpers/resolve-latest-plugin-refs.test.ts
+++ b/tests/helpers/resolve-latest-plugin-refs.test.ts
@@ -1,0 +1,35 @@
+import { Logs } from "@ubiquity-os/ubiquity-os-logger";
+import { resolveLatestPluginRefs } from "../../src/helpers/resolve-latest-plugin-refs.js";
+import type { Context } from "../../src/types/index.js";
+
+describe("resolveLatestPluginRefs", () => {
+  it("pins owner/repo@latest to the default branch commit sha", async () => {
+    const context = {
+      logger: new Logs("info"),
+      octokit: {
+        rest: {
+          repos: {
+            get: jest.fn(async () => ({ data: { default_branch: "development" } })),
+          },
+          git: {
+            getRef: jest.fn(async () => ({ data: { object: { sha: "abc123def456" } } })),
+          },
+        },
+      },
+    } as unknown as Context;
+
+    await expect(resolveLatestPluginRefs("install ubiquity-os-marketplace/command-wallet@latest", context)).resolves.toBe(
+      "install ubiquity-os-marketplace/command-wallet@abc123def456"
+    );
+
+    expect(context.octokit.rest.repos.get).toHaveBeenCalledWith({
+      owner: "ubiquity-os-marketplace",
+      repo: "command-wallet",
+    });
+    expect(context.octokit.rest.git.getRef).toHaveBeenCalledWith({
+      owner: "ubiquity-os-marketplace",
+      repo: "command-wallet",
+      ref: "heads/development",
+    });
+  });
+});


### PR DESCRIPTION
Implements support for pinning plugin installs to the current default-branch commit when the instruction uses @latest.

What changed:
- expands plugin install shorthand before sending the edit request to the LLM
- resolves owner/repo@latest to the repository default branch HEAD SHA through Octokit
- keeps existing owner/repo@ref support unchanged
- adds a focused Jest test for the SHA resolution path

Validation:
- 
pm run jest:test -- --runTestsByPath tests/helpers/resolve-latest-plugin-refs.test.ts
- 
pm exec -- tsc --project tsconfig.json --noEmit
- 
pm exec -- prettier --check src/helpers/plugin-alias.ts src/helpers/process-targets.ts src/helpers/resolve-latest-plugin-refs.ts tests/helpers/resolve-latest-plugin-refs.test.ts

/claim #23